### PR TITLE
compatible php 5.5 strict standards.

### DIFF
--- a/Controller/Component/TwitterComponent.php
+++ b/Controller/Component/TwitterComponent.php
@@ -58,7 +58,7 @@ class TwitterComponent extends Component {
  * @param AppController $controller
  * @param array         $settings
  */
-	public function initialize($controller) {
+	public function initialize(Controller $controller) {
 		$this->Controller = $controller;
 		if ($this->Controller->Components->attached('Auth')) {
 			$url = array('plugin' => 'twim', 'controller' => 'oauth', 'action' => 'login');
@@ -81,7 +81,7 @@ class TwitterComponent extends Component {
  *
  * @param AppController $controller
  */
-	public function startup($controller) {
+	public function startup(Controller $controller) {
 		$this->Controller = $controller;
 	}
 

--- a/Model/Behavior/ExpandTweetEntityBehavior.php
+++ b/Model/Behavior/ExpandTweetEntityBehavior.php
@@ -39,7 +39,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param TwimAppModel $model
  * @param array    $config
  */
-	public function setup($model, $config = array()) {
+	public function setup(Model $model, $config = array()) {
 		$this->settings[$model->name] = Set::merge($this->defaults, $config);
 	}
 
@@ -50,7 +50,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param bool $flag
  * @return TwimAppModel
  */
-	public function setExpandHashtag($model, $flag = true) {
+	public function setExpandHashtag(Model $model, $flag = true) {
 		$this->settings[$model->name]['expandHashtag'] = $flag;
 		return $model;
 	}
@@ -62,7 +62,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param mixed $flag true|false|'string'
  * @return TwimAppModel
  */
-	public function setExpandUrl($model, $flag = true) {
+	public function setExpandUrl(Model $model, $flag = true) {
 		$this->settings[$model->name]['expandUrl'] = $flag;
 		return $model;
 	}
@@ -74,7 +74,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param mixed $flag true|false
  * @return TwimAppModel
  */
-	public function setOverrideText($model, $flag = true) {
+	public function setOverrideText(Model $model, $flag = true) {
 		$this->settings[$model->name]['overrideText'] = $flag;
 		return $model;
 	}
@@ -86,7 +86,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param array $query
  * @return array
  */
-	public function beforeFind($model, $query) {
+	public function beforeFind(Model $model, $query) {
 		if (!isset($query['include_entities'])
 			&& ($this->settings[$model->name]['expandHashtag'] || $this->settings[$model->name]['expandUrl'])) {
 			$model->request['uri']['query']['include_entities'] = true;
@@ -103,7 +103,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param bool $primary
  * @return array
  */
-	public function afterFind($model, $results, $primary) {
+	public function afterFind(Model $model, $results, $primary) {
 		if (empty($results)) {
 			return $results;
 		}
@@ -112,35 +112,35 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
 
 		if ($this->settings[$model->name]['expandHashtag']) {
 			if (!empty($results['statuses'])) {
-				$results['statuses'] = array_map(array($this, 'expandHashtag'), $results['statuses'], array_fill(0, count($results['statuses']), $override));
+				$results['statuses'] = array_map(array($model, 'expandHashtag'), $results['statuses'], array_fill(0, count($results['statuses']), $override));
 			} else if (!empty($results['results'])) {
-				$results['results'] = array_map(array($this, 'expandHashtag'), $results['results'], array_fill(0, count($results['results']), $override));
+				$results['results'] = array_map(array($model, 'expandHashtag'), $results['results'], array_fill(0, count($results['results']), $override));
 			} else if (Set::numeric(array_keys($results))) {
-				$results = array_map(array($this, 'expandHashtag'), $results, array_fill(0, count($results), $override));
+				$results = array_map(array($model, 'expandHashtag'), $results, array_fill(0, count($results), $override));
 			} else if (!empty($results)) {
-				$results = $this->expandHashtag($results, $override);
+				$results = $this->expandHashtag($model, $results, $override);
 			}
 		}
 
 		if ($this->settings[$model->name]['expandUrl'] === 'string') {
 			if (!empty($results['statuses'])) {
-				$results['statuses'] = array_map(array($this, 'expandUrlString'), $results['statuses'], array_fill(0, count($results['statuses']), $override));
+				$results['statuses'] = array_map(array($model, 'expandUrlString'), $results['statuses'], array_fill(0, count($results['statuses']), $override));
 			} else if (!empty($results['results'])) {
-				$results['results'] = array_map(array($this, 'expandUrlString'), $results['results'], array_fill(0, count($results['results']), $override));
+				$results['results'] = array_map(array($model, 'expandUrlString'), $results['results'], array_fill(0, count($results['results']), $override));
 			} else if (Set::numeric(array_keys($results))) {
-				$results = array_map(array($this, 'expandUrlString'), $results, array_fill(0, count($results), $override));
+				$results = array_map(array($model, 'expandUrlString'), $results, array_fill(0, count($results), $override));
 			} else if (!empty($results)) {
-				$results = $this->expandUrlString($results, $override);
+				$results = $this->expandUrlString($model, $results, $override);
 			}
 		} else {
 			if (!empty($results['statuses'])) {
-				$results['statuses'] = array_map(array($this, 'expandUrl'), $results['statuses'], array_fill(0, count($results['statuses']), $override));
+				$results['statuses'] = array_map(array($model, 'expandUrl'), $results['statuses'], array_fill(0, count($results['statuses']), $override));
 			} else if (!empty($results['results'])) {
-				$results['results'] = array_map(array($this, 'expandUrl'), $results['results'], array_fill(0, count($results['results']), $override));
+				$results['results'] = array_map(array($model, 'expandUrl'), $results['results'], array_fill(0, count($results['results']), $override));
 			} else if (Set::numeric(array_keys($results))) {
-				$results = array_map(array($this, 'expandUrl'), $results, array_fill(0, count($results), $override));
+				$results = array_map(array($model, 'expandUrl'), $results, array_fill(0, count($results), $override));
 			} else if (!empty($results)) {
-				$results = $this->expandUrl($results, $override);
+				$results = $this->expandUrl($model, $results, $override);
 			}
 		}
 
@@ -155,7 +155,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param bool $override
  * @return array
  */
-	public function expandHashtag($model, $tweet = null, $override = false) {
+	public function expandHashtag(Model $model, $tweet = null, $override = false) {
 		return $this->_expand('_expandHashtag', 'hashtags', $model, $tweet, $override);
 	}
 
@@ -167,7 +167,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param bool $override
  * @return array
  */
-	public function expandUrl($model, $tweet = null, $override = false) {
+	public function expandUrl(Model $model, $tweet = null, $override = false) {
 		$tweet = $this->_expand('_expandUrl', 'urls', $model, $tweet, $override);
 		return $this->_expand('_expandUrl', 'media', $model, $tweet, $override);
 	}
@@ -180,7 +180,7 @@ class ExpandTweetEntityBehavior extends ModelBehavior {
  * @param bool $override
  * @return array
  */
-	public function expandUrlString($model, $tweet = null, $override = false) {
+	public function expandUrlString(Model $model, $tweet = null, $override = false) {
 		$tweet = $this->_expand('_expandUrlString', 'urls', $model, $tweet, $override);
 		return $this->_expand('_expandUrlString', 'media', $model, $tweet, $override);
 	}

--- a/Model/Behavior/TwitterAuthBehavior.php
+++ b/Model/Behavior/TwitterAuthBehavior.php
@@ -42,7 +42,7 @@ class TwitterAuthBehavior extends ModelBehavior {
  * @param AppModel $model
  * @param array    $config
  */
-	public function setup($model, $config = array()) {
+	public function setup(Model $model, $config = array()) {
 		$this->settings[$model->alias] = Set::merge($this->default, $config);
 	}
 
@@ -53,7 +53,7 @@ class TwitterAuthBehavior extends ModelBehavior {
  * @param  array    $token
  * @return array
  */
-	public function createSaveDataByToken($model, $token) {
+	public function createSaveDataByToken(Model $model, $token) {
 		$data = array(
 			$model->alias => array(
 				$this->settings[$model->alias]['user_id'] => $token['user_id'],

--- a/Model/TwimAccount.php
+++ b/Model/TwimAccount.php
@@ -80,7 +80,7 @@ class TwimAccount extends TwimAppModel {
  * @param array $options
  * @return mixed
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (method_exists($this, '_find' . Inflector::camelize($type))) {
 			return parent::find($type, $options);
 		}

--- a/Model/TwimAppModel.php
+++ b/Model/TwimAppModel.php
@@ -108,7 +108,7 @@ class TwimAppModel extends Model {
 		return ConnectionManager::getDataSource($this->useDbConfig);
 	}
 
-	public function setDataSource($dataSource) {
+	public function setDataSource($dataSource = null) {
 		parent::setDataSource($dataSource);
 		return $this;
 	}

--- a/Model/TwimApplication.php
+++ b/Model/TwimApplication.php
@@ -74,7 +74,7 @@ class TwimApplication extends TwimAppModel {
  * @param array $options
  * @return mixed
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (method_exists($this, '_find' . Inflector::camelize($type))) {
 			return parent::find($type, $options);
 		}

--- a/Model/TwimDirectMessage.php
+++ b/Model/TwimDirectMessage.php
@@ -139,7 +139,7 @@ class TwimDirectMessage extends TwimAppModel {
  * @return mixed
  * @throws RuntimeException
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if ($type === 'all') {
 			$type = 'receipt';
 		}
@@ -349,7 +349,7 @@ class TwimDirectMessage extends TwimAppModel {
  * @return boolean True if such a status exists
  * @access public
  */
-	public function exists() {
+	public function exists($id = null) {
 		if ($this->getID() === false) {
 			return false;
 		}

--- a/Model/TwimFriendship.php
+++ b/Model/TwimFriendship.php
@@ -127,7 +127,7 @@ class TwimFriendship extends TwimAppModel {
  * @param array $options
  * @return mixed
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (!empty($options['limit']) && empty($options['count'])) {
 			$options['count'] = $options['limit'];
 		}
@@ -226,7 +226,7 @@ class TwimFriendship extends TwimAppModel {
  * @param boolean $cascade
  * @return array
  */
-	public function delete($id, $cascade = false) {
+	public function delete($id = null, $cascade = true) {
 		$this->request = array(
 			'uri' => array(
 				'path' => '1.1/friendships/destroy',
@@ -254,7 +254,8 @@ class TwimFriendship extends TwimAppModel {
  * @access public
  * @deprecated since version 2.1.0
  */
-	public function exists($source, $target = null) {
+	public function exists($id = null) {
+		list($source, $target) = func_get_args() + array(null, null);
 		if (is_null($target)) {
 			if ($this->getID() === false) {
 				return false;

--- a/Model/TwimHelp.php
+++ b/Model/TwimHelp.php
@@ -73,7 +73,7 @@ class TwimHelp extends TwimAppModel {
  * @param array $options
  * @return mixed
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (method_exists($this, '_find' . Inflector::camelize($type))) {
 			return parent::find($type, $options);
 		}

--- a/Model/TwimSearch.php
+++ b/Model/TwimSearch.php
@@ -80,7 +80,7 @@ class TwimSearch extends TwimAppModel {
  * @return array
  * @throws InvalidArgumentException
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (is_string($type) && empty($options)) {
 			$options = $type;
 			$type = 'tweets';

--- a/Model/TwimStatus.php
+++ b/Model/TwimStatus.php
@@ -173,7 +173,7 @@ class TwimStatus extends TwimAppModel {
  * @return mixed
  * @throws RuntimeException
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		// change find type api 1.0 -> 1.1
 		if ($type === 'mentions') {
 			$type = 'mentionsTimeline';
@@ -405,7 +405,7 @@ class TwimStatus extends TwimAppModel {
  * @return boolean True if such a status exists
  * @access public
  */
-	public function exists() {
+	public function exists($id = null) {
 		if ($this->getID() === false) {
 			return false;
 		}

--- a/Model/TwimTrend.php
+++ b/Model/TwimTrend.php
@@ -69,7 +69,7 @@ class TwimTrend extends TwimAppModel {
  * @param array $options
  * @return array|false
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (method_exists($this, '_find' . Inflector::camelize($type))) {
 			return parent::find($type, $options);
 		}

--- a/Model/TwimUser.php
+++ b/Model/TwimUser.php
@@ -112,7 +112,7 @@ class TwimUser extends TwimAppModel {
  * @param array $options
  * @return mixed
  */
-	public function find($type, $options = array()) {
+	public function find($type = 'first', $options = array()) {
 		if (Inflector::camelize($type) === 'ProfileImage') {
 			return $this->profileImage($options);
 		}


### PR DESCRIPTION
- PHP 5.5で動作させたところ、オーバーライドしたメソッドのいくつかが Strict Standards  should be compatible になったため、テストケースから確認可能な範囲でStrict Standardsエラーを潰していった。
- 完全にStrictにするために、一部、トリッキーになってしまった部分がある。
  - TwimFriendship::createの引数の数が親メソッドと異なるため、func_get_args()で取得するようにした。
  - 同、デフォルト値については配列の結合で表現するようにした。
- タイプヒンティングを有効にした際にBehaviorの内部のメソッド呼び出しにバグを見つけたため、合わせて修正した。
  - 例：array_map(array($this, 'expandUrlString') を array_map(array($model, 'expandUrlString') にするなど。
