### PR TITLE
Add feature to use POST request method on using find().

### DIFF
--- a/Model/TwimAppModel.php
+++ b/Model/TwimAppModel.php
@@ -164,11 +164,22 @@ class TwimAppModel extends Model {
 			unset($this->request['body']);
 		}
 
+		if (!empty($options['post'])) {
+			if (isset($this->request['uri']['query'])) {
+				$this->request['body'] = $this->request['uri']['query'];
+				unset($this->request['uri']['query']);
+			}
+		}
+
 		return $this;
 	}
 
 	public function beforeFind($queryData) {
 		$this->request['method'] = 'GET';
+		if (!empty($queryData['post'])) {
+			$this->request['method'] = 'POST';
+		}
+
 		return true;
 	}
 

--- a/Test/Case/Model/TwimUserTest.php
+++ b/Test/Case/Model/TwimUserTest.php
@@ -74,6 +74,14 @@ class TwimUserTestCase extends TwimConnectionTestCase {
 		$this->assertSame(array('screen_name' => 'abcd,efgh,ijkl'), $this->User->request['uri']['query']);
 	}
 
+	public function testLookup_use_post() {
+		$this->User->getDataSource()->expects($this->once())->method('request')->will($this->returnValue(false));
+		$this->User->find('lookup', array('screen_name' => array('abcd', 'efgh', 'ijkl'), 'post' => true));
+		$this->assertSame('1.1/users/lookup', $this->User->request['uri']['path']);
+		$this->assertSame('POST', $this->User->request['method']);
+		$this->assertSame(array('screen_name' => 'abcd,efgh,ijkl'), $this->User->request['body']);
+	}
+
 	// =========================================================================
 
 	public function testProfileImage() {


### PR DESCRIPTION
- Some of twitter apis encourages to use POST method for larger requests.
- See https://dev.twitter.com/docs/api/1.1/get/users/lookup for example.
