### PR TITLE
Fix test of Oauth controller

### DIFF
--- a/Test/Case/Controller/OauthControllerTest.php
+++ b/Test/Case/Controller/OauthControllerTest.php
@@ -28,6 +28,8 @@ class OauthControllerTest extends ControllerTestCase {
 
 	public function setUp() {
 		parent::setUp();
+		Router::$routes = array();
+		include CAKE . 'Config' . DS . 'routes.php';
 	}
 
 	public function tearDown() {
@@ -43,13 +45,10 @@ class OauthControllerTest extends ControllerTestCase {
 				'redirect'
 			),)
 		);
-		if ($c->Components->enabled('Auth')) {
-			$c->Auth->loginAction = '/';
-		}
 
-		$c->expects($this->once())->method('redirect')->with('/');
+		$c->expects($this->once())->method('redirect');
 
-		$this->testAction('/twim/oauth/callback', array(
+		$this->_testAction('/twim/oauth/callback', array(
 			'method' => 'get',
 			'data' => array('denied' => 'somekey'),
 		));


### PR DESCRIPTION
- If custom routes uses database it failed that resetting routes can workaround.
- Auth->loginAction could not be overridden when Auth component was configured at some callback such as beforeFilter.
